### PR TITLE
Symbol.Bindings speed up on complex symbols

### DIFF
--- a/MXNETSharp.Tests/executor.fs
+++ b/MXNETSharp.Tests/executor.fs
@@ -29,5 +29,65 @@ module Basic =
         exe.Forward(false)
         Assert.Equal(9.f, exe.Outputs.[0].ToFloat32Scalar())
 
+    // See issue #28
+    [<Fact>]
+    let ``Symbol.Bind timing``() = 
+        let alpha = Variable("alpha")
+        let z = Variable("z")
+        let d = 3.0
+        let T = 50
+        
+        let z0 = (alpha - 1.0).*z
+        let maxZ = Max(z0)
+        let tauMin = maxZ - 1.0
+        let tauMax = maxZ - RpowerScalar(1.0 - alpha, d)
+        
+        let rec loop t (Z : Symbol) (tauMin : Symbol) (tauMax : Symbol) = 
+            let z = z0
+            if t = T then 
+                Z, tauMin, tauMax 
+            else
+                let tau = (tauMin + tauMax) / 2.0
+                let Z = Sum(BroadcastPower(Relu(z .- tau), (1.0 / (alpha - 1.0))))
+                let tauMin,tauMax = 
+                    let cond = Z .< 1.0
+                    Where(cond, tauMin, tau) :> Symbol, 
+                        Where(cond, tau, tauMax) :> Symbol
+                loop (t + 1) Z tauMin tauMax
+        
+        let Z,tau = 
+            let Z, tauMin, tauMax = loop 0 (z0 :> Symbol) tauMin tauMax
+            Z,(tauMin + tauMax) / 2.0
+        
+        let pt = BroadcastPower(Relu(z0 .- tau), (1.0 / (alpha - 1.0)))
+        let r = pt ./ Z
 
+        let inputs = 
+            [
+                Bind.Arg(alpha.Name, shape = [1], opReqType = OpReqType.NullOp, dataType = DataType.Float32, ndarray = NDArray.CopyFrom([|1.0001f|], [1], CPU 0))
+                Bind.Arg(z.Name, shape = [3], opReqType = OpReqType.NullOp, dataType = DataType.Float32, ndarray = NDArray.CopyFrom([|-2.f; 0.f; 0.5f|], [3], CPU 0))
+            ]
+        
+        let q = 
+            inputs
+            |> Bindings.ofSeq
+            |> Bindings.mapArg 
+                (fun a ->
+                    match a.OpReqType with 
+                    | Some NullOp -> {a with Grad = Some(new NDArray())}
+                    | _ -> {a with Grad = Some(MX.ZerosLike(a.NDArray.Value))}
+                )
+            |> Bindings.inferShapes r
+        
+        let f = 
+            async {
+                return r.Bind(CPU 0, q)
+            } |> Async.StartAsTask
+        let mutable waitTime = 10*1000
+        while f.Status <> System.Threading.Tasks.TaskStatus.RanToCompletion && waitTime > 0 do 
+            Async.Sleep 100 |> Async.RunSynchronously
+            waitTime <- waitTime - 100
+        Assert.Equal(System.Threading.Tasks.TaskStatus.RanToCompletion , f.Status)
+        
+        
         

--- a/MXNETSharp.Tests/executor.fs
+++ b/MXNETSharp.Tests/executor.fs
@@ -31,7 +31,7 @@ module Basic =
 
     // See issue #28
     [<Fact>]
-    let ``Symbol.Bind timing``() = 
+    let ``Symbol Bind timing``() = 
         let alpha = Variable("alpha")
         let z = Variable("z")
         let d = 3.0

--- a/MXNetSharp/executor.fs
+++ b/MXNetSharp/executor.fs
@@ -562,37 +562,94 @@ module SymbolExtension =
     open MXNetSharp.SymbolArgument
     type Symbol with 
         member x.Bindings = 
+            let mutable count = 0
+            let mutable count1 = 0
+            let mutable count2 = 0
+            let mutable count3 = 0
+            let mutable count4 = 0
+            let mutable count5 = 0
+            let mutable count6 = 0
+            let mutable count7 = 0
+            let mutable count8 = 0
+            let mutable count9 = 0
+            let mutable count10 = 0
+            let mutable count11 = 0
+            let mutable count12 = 0
+            let mutable count13 = 0
+            let mutable count14 = 0
+            let counts = Dictionary()
+            let c name = 
+                let scc,v = counts.TryGetValue(name)
+                if scc then 
+                    counts.[name] <- v + 1
+                else
+                    counts.[name] <- 1
+            let visited = HashSet<Symbol>({new IEqualityComparer<Symbol> with
+                                               member this.Equals(x: Symbol, y: Symbol): bool = 
+                                                   Object.ReferenceEquals(x,y)
+                                               member this.GetHashCode(obj: Symbol): int = 
+                                                   System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj)})
+
+
             let rec loop (symbol : Symbol) : Parameter seq = 
+                if not(visited.Add symbol) then Seq.empty else
+                count <- count + 1
                 match symbol with 
-                | :? Parameter as p -> Seq.singleton p
-                | :? SymbolOutput as s -> loop s.Parent
+                | :? Parameter as p -> 
+                    count1 <- count1 + 1
+                    Seq.singleton p
+                | :? SymbolOutput as s -> 
+                    count2 <- count2 + 1
+                    loop s.Parent
                 | :? SymbolOperator as s -> 
+                    count3 <- count3 + 1
                     s.OperatorArguments
                     |> Seq.collect
                         (fun a -> 
                             match a with 
                             | name, VarArg(num, args) -> 
+                                count4 <- count4 + 1
                                 args 
                                 |> Seq.collect 
                                     (fun a ->
+                                        count5 <- count5 + 1
                                         match a with 
                                         | :? SymbolOperator as s -> 
+                                            count6 <- count6 + 1
                                             loop s
                                         | :? SymbolOutput as s -> 
+                                            count7 <- count7 + 1
                                             loop s.Parent
                                         | :? Parameter as p -> 
+                                            count8 <- count8 + 1
                                             Seq.singleton p
-                                        | s -> Seq.empty
+                                        | s -> 
+                                            count9 <- count9 + 1
+                                            Seq.empty
                                     )
-                            | name, Input(:? SymbolOperator as s) -> loop s
-                            | name, Input(:? SymbolOutput as s) -> loop s.Parent
-                            | name, Input(:? Parameter as s) -> Seq.singleton s
-                            | otherwise -> Seq.empty
+                            | name, Input(:? SymbolOperator as s) -> 
+                                c (s.Name)
+                                count10 <- count10 + 1
+                                loop s
+                            | name, Input(:? SymbolOutput as s) -> 
+                                count11 <- count11 + 1
+                                loop s.Parent
+                            | name, Input(:? Parameter as s) -> 
+                                count12 <- count12 + 1
+                                Seq.singleton s
+                            | otherwise -> 
+                                count13 <- count13 + 1
+                                Seq.empty
                         )
-                | _ -> Seq.empty
-            loop x 
-            |> Seq.cast
-            |> Bindings.inputs
+                | _ ->
+                    count14 <- count14 + 1
+                    Seq.empty
+            let r = 
+                loop x 
+                |> Seq.cast
+                |> Bindings.inputs
+            printfn "%A  --> %A" x count
+            r
         member x.Bind(context, batchSize, bindings) = 
             let bindmap = x.Bindings.WithBindings(bindings) |> Bindings.batchSize batchSize |> Bindings.inferShapes x
             new Executor(x,context,bindmap)

--- a/MXNetSharp/operator.fs
+++ b/MXNetSharp/operator.fs
@@ -54,10 +54,12 @@ type Arguments<'a>(args : IDictionary<string, OpArg<'a>>, ordering : string []) 
         | w -> failwithf "Expecting %s to be a var arg but is a %A" name w
     interface IEnumerable<string*OpArg<'a>> with
         member x.GetEnumerator() = 
-            let d = Dictionary(args)
             (seq {
-                yield! ordering |> Seq.map (fun m -> d.Remove(m) |> ignore; m,args.[m])
-                yield! d.Keys |> Seq.map (fun k -> k, d.[k])
+                for m in ordering do 
+                    m, args.[m]
+                for kvp in args do 
+                    if not(Array.contains kvp.Key ordering) then 
+                        kvp.Key,kvp.Value
             }).GetEnumerator()
         member this.GetEnumerator() = (this :> IEnumerable<string*OpArg<'a>>).GetEnumerator() :> Collections.IEnumerator
            

--- a/RELEASE_NOTES.MD
+++ b/RELEASE_NOTES.MD
@@ -10,6 +10,7 @@
 * Symbol.Bind now finds Parameter types and uses them as default bindings
 * Issue #25: opening PrimitiveOperators breaks ** operator
 * Executor indexer on Variable for NDArray
+* Issue #28: Symbol.Bindings speed up on complex symbols
 
 #### 0.0.2 (2019-12-13)
 * OpOutCount.txt and OpOutCountRemainder.txt are no longer packaged


### PR DESCRIPTION
Addresses #28

The code give in the issue can be simplified (reducing T) and it becomes apparent it's just taking a really long time.  The problem is `Symbol.Bindings` starts at the root and works back so a 'simple' graph (code from issue with lower T)
![image](https://user-images.githubusercontent.com/7281367/71634182-1811bc80-2bd7-11ea-945f-de5b5d03c196.png)

is visiting the upper nodes in the 100000s of times.

This fix adds a ref equality `HashSet` of visited nodes as Symbol.Bindings loops up the tree.
